### PR TITLE
refactor: replace speech_recognition with ovos plugin manager

### DIFF
--- a/.github/workflows/publish_stable.yml
+++ b/.github/workflows/publish_stable.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.14'
+          python-version: '3.11'
       - name: Install Build Tools
         run: |
           python -m pip install build wheel

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -1,13 +1,13 @@
 name: Release Alpha and Propose Stable
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [closed]
     branches: [dev]
 
 jobs:
   publish_alpha:
-    if: github.event.pull_request.merged == true
     uses: TigreGotico/gh-automations/.github/workflows/publish-alpha.yml@master
     secrets: inherit
     with:
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.14'
+          python-version: '3.11'
       - name: Install Build Tools
         run: |
           python -m pip install build wheel
@@ -75,7 +75,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.14'
+          python-version: '3.11'
 
       - name: Get version from setup.py
         id: get_version

--- a/mycroft_classic_listener/listener.py
+++ b/mycroft_classic_listener/listener.py
@@ -21,7 +21,6 @@ from queue import Queue, Empty
 from threading import Thread
 
 import pyaudio
-import speech_recognition as sr
 from ovos_bus_client.session import SessionManager
 from ovos_config import Configuration
 from ovos_plugin_manager.stt import OVOSSTTFactory as STTFactory
@@ -161,6 +160,7 @@ class AudioConsumer(Thread):
         self.wakeword_recognizer = wakeword_recognizer
 
     def run(self):
+        LOG.info("Waiting for wake word")
         while self.state.running:
             self.read()
 
@@ -235,8 +235,6 @@ class AudioConsumer(Thread):
                 send_unknown_intent()
                 LOG.info('no words were transcribed')
             return text
-        except sr.RequestError as e:
-            LOG.error("Could not request Speech Recognition {0}".format(e))
         except ConnectionError as e:
             LOG.error("Connection Error: {0}".format(e))
 
@@ -363,13 +361,12 @@ class RecognizerLoop(EventEmitter):
                             'configuration')
                 config[word]['threshold'] = thresh
 
-        return HotWordFactory.create_hotword(word, config, self.lang,
-                                             loop=self)
+        return HotWordFactory.create_hotword(word, config)
 
     def create_wakeup_recognizer(self):
         LOG.info("creating stand up word engine")
         word = self.config.get("stand_up_word", "wake up")
-        return HotWordFactory.create_hotword(word, lang=self.lang, loop=self)
+        return HotWordFactory.create_hotword(word)
 
     def start_async(self):
         """Start consumer and producer threads."""

--- a/mycroft_classic_listener/listener.py
+++ b/mycroft_classic_listener/listener.py
@@ -150,6 +150,17 @@ class AudioConsumer(Thread):
 
     def __init__(self, state, queue, emitter, stt,
                  wakeup_recognizer, wakeword_recognizer):
+        """
+        Initialize the AudioConsumer which reads queued audio and dispatches it to wake-word and STT handlers.
+        
+        Parameters:
+            state (RecognizerLoopState): Shared run/sleep state used to control loop behavior.
+            queue (queue.Queue): Source of incoming audio and stream messages.
+            emitter (EventEmitter): Event bus for emitting recognition and control events.
+            stt: Speech-to-text engine used to transcribe audio frames.
+            wakeup_recognizer: Hotword engine that detects a "wake up" phrase to exit sleeping state.
+            wakeword_recognizer: Hotword engine that detects the configured wake word to start recognition.
+        """
         super(AudioConsumer, self).__init__()
         self.daemon = True
         self.queue = queue
@@ -160,6 +171,11 @@ class AudioConsumer(Thread):
         self.wakeword_recognizer = wakeword_recognizer
 
     def run(self):
+        """
+        Continuously consume messages from the audio queue while the consumer is running.
+        
+        Logs that it is waiting for a wake word and repeatedly invokes read() until RecognizerLoopState.running is False.
+        """
         LOG.info("Waiting for wake word")
         while self.state.running:
             self.read()
@@ -221,6 +237,21 @@ class AudioConsumer(Thread):
             LOG.warning("Audio too short to be processed")
 
     def transcribe(self, audio):
+        """
+        Attempt to convert an audio clip to transcribed text.
+        
+        Parameters:
+        	audio: Audio data object containing captured frames and metadata for STT processing.
+        
+        Returns:
+        	str or None: The lowercased, trimmed transcription if successful; `None` if transcription failed or no words were recognized.
+        
+        Notes:
+        	On failure this method emits recognizer loop events:
+        	- emits 'recognizer_loop:speech.recognition.unknown' when no text could be transcribed,
+        	- emits 'recognizer_loop:no_internet' on connection errors.
+        	It also plays a short error audio file before returning `None`.
+        """
         def send_unknown_intent():
             """ Send message that nothing was transcribed. """
             self.emitter.emit('recognizer_loop:speech.recognition.unknown')
@@ -317,16 +348,13 @@ class RecognizerLoop(EventEmitter):
         self.state = RecognizerLoopState()
 
     def create_wake_word_recognizer(self):
-        """Create a local recognizer to hear the wakeup word
-
-        For example 'Hey Mycroft'.
-
-        The method uses the hotword entry for the selected wakeword, if
-        one is missing it will fall back to the old phoneme and threshold in
-        the listener entry in the config.
-
-        If the hotword entry doesn't include phoneme and threshold values these
-        will be patched in using the defaults from the config listnere entry.
+        """
+        Create a local wake word recognizer for the configured wake word.
+        
+        Uses the hotword entry for the configured wake word; if no hotword entry exists, falls back to legacy listener configuration for phonemes and threshold when available. If phoneme or threshold values are missing from both places, the recognizer will be created without those overrides.
+        
+        Returns:
+            recognizer: An instance of the hot word recognizer created by HotWordFactory.
         """
         LOG.info('Creating wake word engine')
         word = self.config.get('wake_word', 'hey mycroft')
@@ -364,12 +392,24 @@ class RecognizerLoop(EventEmitter):
         return HotWordFactory.create_hotword(word, config)
 
     def create_wakeup_recognizer(self):
+        """
+        Create a wake-up hotword recognizer using the configured stand-up word.
+        
+        Reads 'stand_up_word' from the recognizer configuration (defaults to "wake up") and returns a HotWordFactory-created recognizer for that word.
+        
+        Returns:
+            A hotword recognizer instance configured to detect the stand-up word.
+        """
         LOG.info("creating stand up word engine")
         word = self.config.get("stand_up_word", "wake up")
         return HotWordFactory.create_hotword(word)
 
     def start_async(self):
-        """Start consumer and producer threads."""
+        """
+        Start audio producer and consumer threads and prepare streaming support.
+        
+        Sets state.running to True, creates an STT engine and an internal Queue, initializes a stream handler if the STT engine supports streaming, and constructs and starts AudioProducer and AudioConsumer threads (assigned to self.producer and self.consumer).
+        """
         self.state.running = True
         stt = STTFactory.create()
         queue = Queue()

--- a/mycroft_classic_listener/mic.py
+++ b/mycroft_classic_listener/mic.py
@@ -24,17 +24,11 @@ from time import sleep, time as get_time
 
 import pyaudio
 import requests
-import speech_recognition
-from ovos_backend_client.api import DeviceApi
 from ovos_bus_client.session import SessionManager
 from ovos_config import Configuration
 from ovos_utils.log import LOG
 from ovos_utils.sound import play_audio
-from speech_recognition import (
-    Microphone,
-    AudioSource,
-    AudioData
-)
+from ovos_plugin_manager.utils.audio import AudioData, AudioFile
 
 from mycroft_classic_listener.data_structures import RollingMean, CyclicAudioBuffer
 
@@ -116,6 +110,156 @@ class MutableStream:
 
     def stop_stream(self):
         return self.wrapped_stream.stop_stream()
+
+
+# Microphone class extracted from https://github.com/Uberi/speech_recognition
+class Microphone:
+    """
+    Creates a new ``Microphone`` instance, which represents a physical microphone on the computer. Subclass of ``AudioSource``.
+
+    This will throw an ``AttributeError`` if you don't have PyAudio (0.2.11 or later) installed.
+
+    If ``device_index`` is unspecified or ``None``, the default microphone is used as the audio source. Otherwise, ``device_index`` should be the index of the device to use for audio input.
+
+    A device index is an integer between 0 and ``pyaudio.get_device_count() - 1`` (assume we have used ``import pyaudio`` beforehand) inclusive. It represents an audio device such as a microphone or speaker. See the `PyAudio documentation <http://people.csail.mit.edu/hubert/pyaudio/docs/>`__ for more details.
+
+    The microphone audio is recorded in chunks of ``chunk_size`` samples, at a rate of ``sample_rate`` samples per second (Hertz). If not specified, the value of ``sample_rate`` is determined automatically from the system's microphone settings.
+
+    Higher ``sample_rate`` values result in better audio quality, but also more bandwidth (and therefore, slower recognition). Additionally, some CPUs, such as those in older Raspberry Pi models, can't keep up if this value is too high.
+
+    Higher ``chunk_size`` values help avoid triggering on rapidly changing ambient noise, but also makes detection less sensitive. This value, generally, should be left at its default.
+    """
+    def __init__(self, device_index=None, sample_rate=None, chunk_size=1024):
+        assert device_index is None or isinstance(device_index, int), "Device index must be None or an integer"
+        assert sample_rate is None or (isinstance(sample_rate, int) and sample_rate > 0), "Sample rate must be None or a positive integer"
+        assert isinstance(chunk_size, int) and chunk_size > 0, "Chunk size must be a positive integer"
+
+        # set up PyAudio
+        self.pyaudio_module = self.get_pyaudio()
+        audio = self.pyaudio_module.PyAudio()
+        try:
+            count = audio.get_device_count()  # obtain device count
+            if device_index is not None:  # ensure device index is in range
+                assert 0 <= device_index < count, "Device index out of range ({} devices available; device index should be between 0 and {} inclusive)".format(count, count - 1)
+            if sample_rate is None:  # automatically set the sample rate to the hardware's default sample rate if not specified
+                device_info = audio.get_device_info_by_index(device_index) if device_index is not None else audio.get_default_input_device_info()
+                assert isinstance(device_info.get("defaultSampleRate"), (float, int)) and device_info["defaultSampleRate"] > 0, "Invalid device info returned from PyAudio: {}".format(device_info)
+                sample_rate = int(device_info["defaultSampleRate"])
+        finally:
+            audio.terminate()
+
+        self.device_index = device_index
+        self.format = self.pyaudio_module.paInt16  # 16-bit int sampling
+        self.SAMPLE_WIDTH = self.pyaudio_module.get_sample_size(self.format)  # size of each sample
+        self.SAMPLE_RATE = sample_rate  # sampling rate in Hertz
+        self.CHUNK = chunk_size  # number of frames stored in each buffer
+
+        self.audio = None
+        self.stream = None
+
+    @staticmethod
+    def get_pyaudio():
+        """
+        Imports the pyaudio module and checks its version. Throws exceptions if pyaudio can't be found or a wrong version is installed
+        """
+        try:
+            import pyaudio
+        except ImportError:
+            raise AttributeError("Could not find PyAudio; check installation")
+        return pyaudio
+
+    @staticmethod
+    def list_microphone_names():
+        """
+        Returns a list of the names of all available microphones. For microphones where the name can't be retrieved, the list entry contains ``None`` instead.
+
+        The index of each microphone's name in the returned list is the same as its device index when creating a ``Microphone`` instance - if you want to use the microphone at index 3 in the returned list, use ``Microphone(device_index=3)``.
+        """
+        audio = Microphone.get_pyaudio().PyAudio()
+        try:
+            result = []
+            for i in range(audio.get_device_count()):
+                device_info = audio.get_device_info_by_index(i)
+                result.append(device_info.get("name"))
+        finally:
+            audio.terminate()
+        return result
+
+    @staticmethod
+    def list_working_microphones():
+        """
+        Returns a dictionary mapping device indices to microphone names, for microphones that are currently hearing sounds. When using this function, ensure that your microphone is unmuted and make some noise at it to ensure it will be detected as working.
+
+        Each key in the returned dictionary can be passed to the ``Microphone`` constructor to use that microphone. For example, if the return value is ``{3: "HDA Intel PCH: ALC3232 Analog (hw:1,0)"}``, you can do ``Microphone(device_index=3)`` to use that microphone.
+        """
+        pyaudio_module = Microphone.get_pyaudio()
+        audio = pyaudio_module.PyAudio()
+        try:
+            result = {}
+            for device_index in range(audio.get_device_count()):
+                device_info = audio.get_device_info_by_index(device_index)
+                device_name = device_info.get("name")
+                assert isinstance(device_info.get("defaultSampleRate"), (float, int)) and device_info["defaultSampleRate"] > 0, "Invalid device info returned from PyAudio: {}".format(device_info)
+                try:
+                    # read audio
+                    pyaudio_stream = audio.open(
+                        input_device_index=device_index, channels=1, format=pyaudio_module.paInt16,
+                        rate=int(device_info["defaultSampleRate"]), input=True
+                    )
+                    try:
+                        buffer = pyaudio_stream.read(1024)
+                        if not pyaudio_stream.is_stopped(): pyaudio_stream.stop_stream()
+                    finally:
+                        pyaudio_stream.close()
+                except Exception:
+                    continue
+
+                # compute RMS of debiased audio
+                energy = -audioop.rms(buffer, 2)
+                energy_bytes = bytes([energy & 0xFF, (energy >> 8) & 0xFF])
+                debiased_energy = audioop.rms(audioop.add(buffer, energy_bytes * (len(buffer) // 2), 2), 2)
+
+                if debiased_energy > 30:  # probably actually audio
+                    result[device_index] = device_name
+        finally:
+            audio.terminate()
+        return result
+
+    def __enter__(self):
+        assert self.stream is None, "This audio source is already inside a context manager"
+        self.audio = self.pyaudio_module.PyAudio()
+        try:
+            self.stream = Microphone.MicrophoneStream(
+                self.audio.open(
+                    input_device_index=self.device_index, channels=1, format=self.format,
+                    rate=self.SAMPLE_RATE, frames_per_buffer=self.CHUNK, input=True,
+                )
+            )
+        except Exception:
+            self.audio.terminate()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        try:
+            self.stream.close()
+        finally:
+            self.stream = None
+            self.audio.terminate()
+
+    class MicrophoneStream(object):
+        def __init__(self, pyaudio_stream):
+            self.pyaudio_stream = pyaudio_stream
+
+        def read(self, size):
+            return self.pyaudio_stream.read(size, exception_on_overflow=False)
+
+        def close(self):
+            try:
+                # sometimes, if the stream isn't stopped, closing the stream throws an exception
+                if not self.pyaudio_stream.is_stopped():
+                    self.pyaudio_stream.stop_stream()
+            finally:
+                self.pyaudio_stream.close()
 
 
 class MutableMicrophone(Microphone):
@@ -303,7 +447,7 @@ class NoiseTracker:
                 (self._loud_enough() or too_much_silence))
 
 
-class ResponsiveRecognizer(speech_recognition.Recognizer):
+class ResponsiveRecognizer:
     # Padding of silence when feeding to pocketsphinx
     SILENCE_SEC = 0.01
 
@@ -328,7 +472,16 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
 
         self.overflow_exc = listener_config.get('overflow_exception', False)
 
-        super().__init__()
+        self.energy_threshold = 300  # minimum audio energy to consider for recording
+        self.dynamic_energy_threshold = True
+        self.dynamic_energy_adjustment_damping = 0.15
+        self.dynamic_energy_ratio = 1.5
+        self.pause_threshold = 0.8  # seconds of non-speaking audio before a phrase is considered complete
+        self.operation_timeout = None  # seconds after an internal operation (e.g., an API request) starts before it times out, or ``None`` for no timeout
+
+        self.phrase_threshold = 0.3  # minimum seconds of speaking audio before we consider the speaking audio a phrase - values below this are ignored (for filtering out clicks and pops)
+        self.non_speaking_duration = 0.5  # seconds of non-speaking audio to keep on both sides of the recording
+
         self.wake_word_recognizer = wake_word_recognizer
         self.audio = pyaudio.PyAudio()
         self.multiplier = listener_config.get('multiplier')
@@ -350,7 +503,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         self._stop_signaled = False
         self._listen_triggered = False
 
-        self._account_id = None
+        self.account_id = "0"
 
         # The maximum seconds a phrase can be recorded,
         # provided there is noise the entire time
@@ -362,23 +515,33 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         self.recording_timeout_with_silence = listener_config.get(
             'recording_timeout_with_silence', 3.0)
 
-    @property
-    def account_id(self):
-        """Fetch account from backend when needed.
-
-        If an error occurs it's handled and a temporary value is returned.
-        When a value is received it will be cached until next start.
+    # extracted from https://github.com/Uberi/speech_recognition
+    def adjust_for_ambient_noise(self, source: Microphone, duration: float = 1) -> None:
         """
-        if not self._account_id:
-            try:
-                self._account_id = DeviceApi().get()['user']['uuid']
-            except (requests.RequestException, AttributeError):
-                pass  # These are expected and won't be reported
-            except Exception as e:
-                LOG.debug('Unhandled exception while determining device_id, '
-                          'Error: {}'.format(repr(e)))
+        Adjusts the energy threshold dynamically using audio from ``source`` (an ``AudioSource`` instance) to account for ambient noise.
 
-        return self._account_id or '0'
+        Intended to calibrate the energy threshold with the ambient energy level. Should be used on periods of audio without speech - will stop early if any speech is detected.
+
+        The ``duration`` parameter is the maximum number of seconds that it will dynamically adjust the threshold for before returning. This value should be at least 0.5 in order to get a representative sample of the ambient noise.
+        """
+        assert isinstance(source, Microphone), "Source must be an audio source"
+        assert source.stream is not None, "Audio source must be entered before adjusting, see documentation for ``AudioSource``; are you using ``source`` outside of a ``with`` statement?"  # type: ignore[attr-defined]
+        assert self.pause_threshold >= self.non_speaking_duration >= 0
+
+        seconds_per_buffer = (source.CHUNK + 0.0) / source.SAMPLE_RATE  # type: ignore[attr-defined]
+        elapsed_time = 0
+
+        # adjust energy threshold until a phrase starts
+        while True:
+            elapsed_time += seconds_per_buffer
+            if elapsed_time > duration: break
+            buffer = source.stream.read(source.CHUNK)  # type: ignore[attr-defined]
+            energy = audioop.rms(buffer, source.SAMPLE_WIDTH)  # type: ignore[attr-defined]  # energy of the audio signal
+
+            # dynamically adjust the energy threshold using asymmetric weighted average
+            damping = self.dynamic_energy_adjustment_damping ** seconds_per_buffer  # account for different chunk sizes and rates
+            target_energy = energy * self.dynamic_energy_ratio
+            self.energy_threshold = self.energy_threshold * damping + target_energy * (1 - damping)
 
     def record_sound_chunk(self, source):
         return source.stream.read(source.CHUNK, self.overflow_exc)
@@ -401,7 +564,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         a buffer of self.recording_timeout duration.
 
         Args:
-            source (AudioSource):  Source producing the audio chunks
+            source (Microphone):  Source producing the audio chunks
             sec_per_buffer (float):  Fractional number of seconds in each chunk
             stream (AudioStreamHandler): Stream target that will receive chunks
                                          of the utterance audio while it is
@@ -554,14 +717,13 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         """Listen continuously on source until a wake word is spoken
 
         Args:
-            source (AudioSource):  Source producing the audio chunks
+            source (Microphone):  Source producing the audio chunks
             sec_per_buffer (float):  Fractional number of seconds in each chunk
         """
 
         # The maximum audio in seconds to keep for transcribing a phrase
         # The wake word must fit in this time
-        ww_duration = self.wake_word_recognizer.expected_duration
-        ww_test_duration = max(3, ww_duration)
+        ww_duration = ww_test_duration = 3
 
         mic_write_counter = 0
         num_silent_bytes = int(self.SILENCE_SEC * source.SAMPLE_RATE *
@@ -618,8 +780,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
             if buffers_since_check > buffers_per_check:
                 buffers_since_check -= buffers_per_check
                 audio_data = audio_buffer.get_last(test_size) + silence
-                said_wake_word = \
-                    self.wake_word_recognizer.found_wake_word(audio_data)
+                said_wake_word = self.wake_word_recognizer.found_wake_word()
 
         self._listen_triggered = False
         return WakeWordData(audio_data, said_wake_word,
@@ -651,7 +812,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         afterwards.
 
         Args:
-            source (AudioSource):  Source producing the audio chunks
+            source (Microphone):  Source producing the audio chunks
             emitter (EventEmitter): Emitter for notifications of when recording
                                     begins and ends.
             stream (AudioStreamHandler): Stream target that will receive chunks
@@ -661,7 +822,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         Returns:
             AudioData: audio with the user's utterance, minus the wake-up-word
         """
-        assert isinstance(source, AudioSource), "Source must be an AudioSource"
+        assert isinstance(source, Microphone), "Source must be a Microphone"
 
         #        bytes_per_sec = source.SAMPLE_RATE * source.SAMPLE_WIDTH
         sec_per_buffer = float(source.CHUNK) / source.SAMPLE_RATE

--- a/mycroft_classic_listener/mic.py
+++ b/mycroft_classic_listener/mic.py
@@ -109,6 +109,12 @@ class MutableStream:
             return True  # Assume the stream has been closed and thusly stopped
 
     def stop_stream(self):
+        """
+        Stop the underlying wrapped audio stream.
+        
+        Returns:
+            The value returned by the wrapped stream's `stop_stream()` call (typically `None`).
+        """
         return self.wrapped_stream.stop_stream()
 
 
@@ -130,6 +136,20 @@ class Microphone:
     Higher ``chunk_size`` values help avoid triggering on rapidly changing ambient noise, but also makes detection less sensitive. This value, generally, should be left at its default.
     """
     def __init__(self, device_index=None, sample_rate=None, chunk_size=1024):
+        """
+        Initialize a Microphone instance, selecting the audio device and configuring sample parameters.
+        
+        Parameters:
+            device_index (int | None): Index of the input device to use; if None, the default input device is used.
+            sample_rate (int | None): Desired sampling rate in Hz; if None, the device's default sample rate is used.
+            chunk_size (int): Number of audio frames per buffer (CHUNK).
+        
+        Raises:
+            AssertionError: If arguments are invalid (wrong types or out of range) or if the selected device reports an invalid default sample rate.
+        
+        Side effects:
+            Queries PyAudio for device information and sets instance attributes: pyaudio_module, device_index, format, SAMPLE_WIDTH, SAMPLE_RATE, CHUNK, audio, and stream.
+        """
         assert device_index is None or isinstance(device_index, int), "Device index must be None or an integer"
         assert sample_rate is None or (isinstance(sample_rate, int) and sample_rate > 0), "Sample rate must be None or a positive integer"
         assert isinstance(chunk_size, int) and chunk_size > 0, "Chunk size must be a positive integer"
@@ -160,7 +180,13 @@ class Microphone:
     @staticmethod
     def get_pyaudio():
         """
-        Imports the pyaudio module and checks its version. Throws exceptions if pyaudio can't be found or a wrong version is installed
+        Import and return the PyAudio module, raising an error if it is not available.
+        
+        Returns:
+            pyaudio: The imported PyAudio module.
+        
+        Raises:
+            AttributeError: If the PyAudio package is not installed.
         """
         try:
             import pyaudio
@@ -171,9 +197,12 @@ class Microphone:
     @staticmethod
     def list_microphone_names():
         """
-        Returns a list of the names of all available microphones. For microphones where the name can't be retrieved, the list entry contains ``None`` instead.
-
-        The index of each microphone's name in the returned list is the same as its device index when creating a ``Microphone`` instance - if you want to use the microphone at index 3 in the returned list, use ``Microphone(device_index=3)``.
+        List the display names of all available audio input devices.
+        
+        Each entry corresponds to the device index used when creating a Microphone (e.g., the name at index 3 is for Microphone(device_index=3)). If a device's name cannot be retrieved, its entry will be `None`.
+        
+        Returns:
+            list: A list of device names (strings) or `None` for devices with no retrievable name.
         """
         audio = Microphone.get_pyaudio().PyAudio()
         try:
@@ -188,9 +217,12 @@ class Microphone:
     @staticmethod
     def list_working_microphones():
         """
-        Returns a dictionary mapping device indices to microphone names, for microphones that are currently hearing sounds. When using this function, ensure that your microphone is unmuted and make some noise at it to ensure it will be detected as working.
-
-        Each key in the returned dictionary can be passed to the ``Microphone`` constructor to use that microphone. For example, if the return value is ``{3: "HDA Intel PCH: ALC3232 Analog (hw:1,0)"}``, you can do ``Microphone(device_index=3)`` to use that microphone.
+        Detects microphones that are currently producing audible input.
+        
+        Callers should ensure the microphone is unmuted and produce sound while this runs so active devices are detected.
+        
+        Returns:
+            result (dict): Mapping of device index (int) to microphone name (str) for devices that appear to be receiving audio; empty if none detected.
         """
         pyaudio_module = Microphone.get_pyaudio()
         audio = pyaudio_module.PyAudio()
@@ -226,6 +258,16 @@ class Microphone:
         return result
 
     def __enter__(self):
+        """
+        Enter the microphone context and open the underlying PyAudio stream.
+        
+        If opening the stream succeeds, stores a MicrophoneStream in self.stream and the PyAudio
+        instance in self.audio. If opening the stream raises an exception, the PyAudio instance
+        is terminated and no stream is retained.
+        
+        Returns:
+            self: The Microphone instance with an opened stream when successful.
+        """
         assert self.stream is None, "This audio source is already inside a context manager"
         self.audio = self.pyaudio_module.PyAudio()
         try:
@@ -240,6 +282,11 @@ class Microphone:
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
+        """
+        Close the microphone stream and terminate the PyAudio instance when exiting the context.
+        
+        Ensures the stream is closed and the stream reference is cleared even if closing raises an error; always calls audio.terminate(). Does not suppress exceptions from the surrounding context.
+        """
         try:
             self.stream.close()
         finally:
@@ -248,12 +295,32 @@ class Microphone:
 
     class MicrophoneStream(object):
         def __init__(self, pyaudio_stream):
+            """
+            Initialize the MicrophoneStream wrapper.
+            
+            Parameters:
+                pyaudio_stream: The active PyAudio stream object to wrap; expected to provide read(size, exception_on_overflow=False), stop_stream(), and close() methods.
+            """
             self.pyaudio_stream = pyaudio_stream
 
         def read(self, size):
+            """
+            Read up to `size` frames of audio from the underlying PyAudio stream without raising on buffer overflow.
+            
+            Parameters:
+                size (int): Number of frames to read from the stream.
+            
+            Returns:
+                bytes: Raw audio bytes for the frames read.
+            """
             return self.pyaudio_stream.read(size, exception_on_overflow=False)
 
         def close(self):
+            """
+            Stop and close the underlying PyAudio stream.
+            
+            If the stream is not already stopped, attempts to stop it before closing the stream to release resources.
+            """
             try:
                 # sometimes, if the stream isn't stopped, closing the stream throws an exception
                 if not self.pyaudio_stream.is_stopped():
@@ -265,8 +332,16 @@ class Microphone:
 class MutableMicrophone(Microphone):
     def __init__(self, device_index=None, sample_rate=16000, chunk_size=1024,
                  mute=False):
-        Microphone.__init__(self, device_index=device_index,
-                            sample_rate=sample_rate, chunk_size=chunk_size)
+        """
+        Initialize a MutableMicrophone configured for a specific input device and audio parameters, and set its initial mute state.
+        
+        Parameters:
+            device_index (int or None): Index of the audio input device to use, or None to auto-select the default.
+            sample_rate (int): Sampling rate in Hz for audio capture.
+            chunk_size (int): Number of frames per read from the audio stream.
+            mute (bool): If True, start the microphone muted; otherwise start unmuted.
+        """
+        Microphone.__init__(self, device_index=device_index, sample_rate=sample_rate, chunk_size=chunk_size)
         self.muted = False
         if mute:
             self.mute()
@@ -430,13 +505,16 @@ class NoiseTracker:
         return self.level <= self.min_level
 
     def recording_complete(self):
-        """Has the end creteria for the recording been met.
-
-        If the noise level has decresed from a loud level to a low level
-        the user has stopped speaking.
-
-        Alternatively if a lot of silence was recorded without detecting
-        a loud enough phrase.
+        """
+        Determine whether the current recording should be considered complete.
+        
+        The recording is considered complete when the noise level is at or below
+        the quiet threshold for longer than `silence_after_loud` and either
+        enough loud chunks have been observed to qualify as a phrase or the
+        recording has exceeded `max_silence_duration`.
+        
+        Returns:
+            bool: `True` if the recording end criteria are met, `False` otherwise.
         """
         too_much_silence = (self.silence_duration > self.max_silence_duration)
         if too_much_silence:
@@ -463,6 +541,15 @@ class ResponsiveRecognizer:
     SEC_BETWEEN_WW_CHECKS = 0.2
 
     def __init__(self, wake_word_recognizer, watchdog=None):
+        """
+        Initialize the ResponsiveRecognizer with the given wake-word recognizer and optional watchdog.
+        
+        Loads listener configuration, initializes audio and dynamic energy thresholding parameters, recording timeouts, and directories for saving captured wake words and utterances (if enabled). Also stores flags and internal state used to control listening and recording behaviour.
+        
+        Parameters:
+            wake_word_recognizer: An object responsible for detecting wake words; must expose `key_phrase` and provide the detection interface used by this class.
+            watchdog (callable, optional): A callable invoked periodically for liveness monitoring; defaults to a no-op if not provided.
+        """
         self._watchdog = watchdog or (lambda: None)  # Default to dummy func
         self.config = Configuration()
         listener_config = self.config.get('listener')
@@ -518,11 +605,13 @@ class ResponsiveRecognizer:
     # extracted from https://github.com/Uberi/speech_recognition
     def adjust_for_ambient_noise(self, source: Microphone, duration: float = 1) -> None:
         """
-        Adjusts the energy threshold dynamically using audio from ``source`` (an ``AudioSource`` instance) to account for ambient noise.
-
-        Intended to calibrate the energy threshold with the ambient energy level. Should be used on periods of audio without speech - will stop early if any speech is detected.
-
-        The ``duration`` parameter is the maximum number of seconds that it will dynamically adjust the threshold for before returning. This value should be at least 0.5 in order to get a representative sample of the ambient noise.
+        Calibrates the recognizer's energy threshold from ambient noise captured by a Microphone.
+        
+        Reads audio chunks from the provided Microphone (which must be entered and have an active stream) for up to `duration` seconds and updates `self.energy_threshold` using a damping-weighted average of measured RMS energy scaled by `self.dynamic_energy_ratio`. Intended to tune sensitivity to current background noise; callers should ensure the sampled period does not contain speech.
+        
+        Parameters:
+            source (Microphone): An entered Microphone instance with an active stream.
+            duration (float): Maximum number of seconds to sample ambient audio (should be >= 0.5 for representative calibration).
         """
         assert isinstance(source, Microphone), "Source must be an audio source"
         assert source.stream is not None, "Audio source must be entered before adjusting, see documentation for ``AudioSource``; are you using ``source`` outside of a ``with`` statement?"  # type: ignore[attr-defined]
@@ -544,6 +633,15 @@ class ResponsiveRecognizer:
             self.energy_threshold = self.energy_threshold * damping + target_energy * (1 - damping)
 
     def record_sound_chunk(self, source):
+        """
+        Read a single audio chunk from the microphone stream.
+        
+        Parameters:
+            source (Microphone): An active Microphone instance with an open stream.
+        
+        Returns:
+            bytes: Raw audio bytes for one chunk (size = source.CHUNK * sample width).
+        """
         return source.stream.read(source.CHUNK, self.overflow_exc)
 
     @staticmethod
@@ -557,24 +655,17 @@ class ResponsiveRecognizer:
             stream=None,
             ww_frames=None
     ):
-        """Record an entire spoken phrase.
-
-        Essentially, this code waits for a period of silence and then returns
-        the audio.  If silence isn't detected, it will terminate and return
-        a buffer of self.recording_timeout duration.
-
-        Args:
-            source (Microphone):  Source producing the audio chunks
-            sec_per_buffer (float):  Fractional number of seconds in each chunk
-            stream (AudioStreamHandler): Stream target that will receive chunks
-                                         of the utterance audio while it is
-                                         being recorded.
-            ww_frames (deque):  Frames of audio data from the last part of wake
-                                word detection.
-
+        """
+        Record audio for a single spoken phrase until end-of-utterance silence or a timeout.
+        
+        Parameters:
+            source (Microphone): Active microphone providing audio chunks (must have SAMPLE_WIDTH).
+            sec_per_buffer (float): Duration in seconds of each audio chunk read from the source.
+            stream (optional): Target with stream_start() and stream_chunk(bytes) to receive chunks as they are recorded.
+            ww_frames (optional deque): Pre-filled frames from wake-word detection to prepend to the recording.
+        
         Returns:
-            bytearray: complete audio buffer recorded, including any
-                       silence at the end of the user's utterance
+            bytearray: Recorded audio bytes for the phrase, including any trailing silence.
         """
         noise_tracker = NoiseTracker(0, 25, sec_per_buffer,
                                      self.MIN_LOUD_SEC_PER_PHRASE,
@@ -714,11 +805,19 @@ class ResponsiveRecognizer:
                 self._upload_wakeword(audio, metadata)
 
     def _wait_until_wake_word(self, source, sec_per_buffer):
-        """Listen continuously on source until a wake word is spoken
-
+        """
+        Listen to the given Microphone until a wake word is detected or listening is stopped.
+        
         Args:
-            source (Microphone):  Source producing the audio chunks
-            sec_per_buffer (float):  Fractional number of seconds in each chunk
+            source (Microphone): Audio source providing chunks and metadata (sample rate/width).
+            sec_per_buffer (float): Duration in seconds of each audio chunk.
+        
+        Returns:
+            WakeWordData: Named tuple with fields:
+                - audio: bytes of the audio immediately preceding detection (plus trailing silence) suitable for STT.
+                - found: `True` if a wake word was detected, `False` otherwise.
+                - stopped: `True` if listening was interrupted via stop signal, `False` otherwise.
+                - end_audio: deque of the raw frames captured immediately after detection (may be empty).
         """
 
         # The maximum audio in seconds to keep for transcribing a phrase
@@ -805,22 +904,18 @@ class ResponsiveRecognizer:
             return False
 
     def listen(self, source, emitter, stream=None):
-        """Listens for chunks of audio that Mycroft should perform STT on.
-
-        This will listen continuously for a wake-up-word, then return the
-        audio chunk containing the spoken phrase that comes immediately
-        afterwards.
-
-        Args:
-            source (Microphone):  Source producing the audio chunks
-            emitter (EventEmitter): Emitter for notifications of when recording
-                                    begins and ends.
-            stream (AudioStreamHandler): Stream target that will receive chunks
-                                         of the utterance audio while it is
-                                         being recorded
-
+        """
+        Listen for a wake word and record the user's utterance that immediately follows.
+        
+        Waits for a wake word from the provided Microphone source, emits start/stop events via the emitter, optionally plays a confirmation sound, records the following phrase (excluding the wake word), and may save the utterance to disk depending on configuration.
+        
+        Parameters:
+            source (Microphone): Microphone producing audio chunks; must be entered/active.
+            emitter (EventEmitter): Event emitter used to signal "recognizer_loop:record_begin" and "recognizer_loop:record_end".
+            stream (AudioStreamHandler): Optional stream target that will receive utterance chunks while recording.
+        
         Returns:
-            AudioData: audio with the user's utterance, minus the wake-up-word
+            AudioData: Recorded audio containing the user's utterance, excluding the wake word.
         """
         assert isinstance(source, Microphone), "Source must be a Microphone"
 

--- a/mycroft_classic_listener/service.py
+++ b/mycroft_classic_listener/service.py
@@ -14,7 +14,6 @@
 #
 from threading import Lock, Thread
 
-from ovos_backend_client.identity import IdentityManager
 from ovos_bus_client.client import MessageBusClient
 from ovos_bus_client.message import Message
 from ovos_config import Configuration
@@ -127,15 +126,6 @@ def handle_mic_get_status(event):
     bus.emit(event.response(data))
 
 
-def handle_paired(event):
-    """Update identity information with pairing data.
-
-    This is done here to make sure it's only done in a single place.
-    TODO: Is there a reason this isn't done directly in the pairing skill?
-    """
-    IdentityManager.update(event.data)
-
-
 def handle_audio_start(event):
     """Mute recognizer loop."""
     if config.get("listener").get("mute_during_output"):
@@ -193,7 +183,6 @@ def connect_bus_events(bus):
     bus.on('mycroft.mic.unmute', handle_mic_unmute)
     bus.on('mycroft.mic.get_status', handle_mic_get_status)
     bus.on('mycroft.mic.listen', handle_mic_listen)
-    bus.on("mycroft.paired", handle_paired)
     bus.on('recognizer_loop:audio_output_start', handle_audio_start)
     bus.on('recognizer_loop:audio_output_end', handle_audio_end)
     bus.on('mycroft.stop', handle_stop)

--- a/mycroft_classic_listener/service.py
+++ b/mycroft_classic_listener/service.py
@@ -121,13 +121,23 @@ def handle_mic_listen(_):
 
 
 def handle_mic_get_status(event):
-    """Query microphone mute status."""
+    """
+    Query the current microphone mute state and emit it as a response on the provided event.
+    
+    Parameters:
+        event: Message-like object with a `response(data)` method used to send the result. The emitted response contains `{'muted': True}` if the microphone is muted, `{'muted': False}` otherwise.
+    """
     data = {'muted': loop.is_muted()}
     bus.emit(event.response(data))
 
 
 def handle_audio_start(event):
-    """Mute recognizer loop."""
+    """
+    Mute the recognizer loop when audio output begins if configured.
+    
+    Parameters:
+        event: The incoming message/event that triggered audio start (unused).
+    """
     if config.get("listener").get("mute_during_output"):
         loop.mute()
 
@@ -176,6 +186,14 @@ def connect_loop_events(loop):
 
 def connect_bus_events(bus):
     # Register handlers for events on main Mycroft messagebus
+    """
+    Register message-bus event handlers used by the speech listener.
+    
+    Binds internal handler functions to the bus topics the listener expects (e.g., open, sleep/wake, microphone control, audio output events, and stop).
+    
+    Parameters:
+    	bus: The message bus client on which to register event handlers.
+    """
     bus.on('open', handle_open)
     bus.on('recognizer_loop:sleep', handle_sleep)
     bus.on('recognizer_loop:wake_up', handle_wake_up)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-SpeechRecognition>=3.8.1
 PyAudio~=0.2
-ovos-utils>=0.7.0,<1.0.0
-ovos-bus-client>=0.1.6,<2.0.0
-ovos-plugin-manager>=0.8.3,<1.0.0
-ovos-config>=0.4.6,<2.0.0
+ovos-plugin-manager>=2.1.1,<3.0.0
+ovos-utils>=0.8.4,<1.0.0
+ovos-config>=1.2.2,<3.0.0
+ovos_bus_client>=1.3.4,<2.0.0


### PR DESCRIPTION
allow latest ovos-plugin-manager

drop dependency on speech_recognition library

drop dependency on ovos-backend-client (deprecated)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added microphone utility methods to enumerate available devices and detect working microphones.

* **Bug Fixes**
  * Improved ambient-noise calibration mechanism.

* **Refactor**
  * Replaced external speech recognition library with self-contained implementation.
  * Simplified hot word factory API.
  * Removed pairing event handling from service.

* **Chores**
  * Updated Python version to 3.11.
  * Updated dependency versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->