### PR TITLE
fix(deps): allow ovos-bus-client 2.x (widen cap to <3.0.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "ovos-plugin-manager>=2.1.1,<3.0.0",
     "ovos-utils>=0.8.4,<1.0.0",
     "ovos-config>=1.2.2,<3.0.0",
-    "ovos_bus_client>=1.3.4,<2.0.0",
+    "ovos_bus_client>=1.3.4,<3.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
ovos-bus-client 2.x dropped only the bundled hivemind protocol + messagebus solver (#207) — no API break (#215). Widen `<2.0.0`→`<3.0.0` (1.x stays default). Stack-wide migration for HiveMind 2.x adoption.