### PR TITLE
feat!: migrate bus topics to ovos spec namespace

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,4 +14,5 @@ jobs:
       coverage_source: 'mycroft_classic_listener'
       test_path: 'test/'
       install_extras: ''
+      system_deps: 'portaudio19-dev'
       min_coverage: 0

--- a/mycroft_classic_listener/service.py
+++ b/mycroft_classic_listener/service.py
@@ -16,6 +16,7 @@ from threading import Lock, Thread
 
 from ovos_bus_client.client import MessageBusClient
 from ovos_bus_client.message import Message
+from ovos_spec_tools import SpecMessage
 from ovos_config import Configuration
 from ovos_utils.thread_utils import wait_for_exit_signal
 from ovos_bus_client.apis.enclosure import EnclosureAPI
@@ -34,14 +35,14 @@ def handle_record_begin():
     """Forward internal bus message to external bus."""
     LOG.info("Begin Recording...")
     context = {"client_name": "mycroft_listener", "source": "audio"}
-    bus.emit(Message("recognizer_loop:record_begin", context=context))
+    bus.emit(Message(SpecMessage.LISTENER_RECORD_STARTED, context=context))
 
 
 def handle_record_end():
     """Forward internal bus message to external bus."""
     LOG.info("End Recording...")
     context = {"client_name": "mycroft_listener", "source": "audio"}
-    bus.emit(Message("recognizer_loop:record_end", context=context))
+    bus.emit(Message(SpecMessage.LISTENER_RECORD_ENDED, context=context))
 
 
 def handle_no_internet():
@@ -54,7 +55,7 @@ def handle_awoken():
     """Forward mycroft.awoken to the messagebus."""
     LOG.info("Listener is now Awake: ")
     context = {"client_name": "mycroft_listener", "source": "audio"}
-    bus.emit(Message("mycroft.awoken", context=context))
+    bus.emit(Message(SpecMessage.LISTENER_AWOKEN, context=context))
 
 
 def handle_wakeword(event):
@@ -72,7 +73,7 @@ def handle_utterance(event):
     if "ident" in event:
         ident = event.pop("ident")
         context["ident"] = ident
-    bus.emit(Message("recognizer_loop:utterance", event, context))
+    bus.emit(Message(SpecMessage.UTTERANCE, event, context))
 
 
 def handle_unknown():
@@ -191,14 +192,14 @@ def connect_bus_events(bus):
         bus: The message bus client on which to register event handlers.
     """
     bus.on("open", handle_open)
-    bus.on("recognizer_loop:sleep", handle_sleep)
+    bus.on(SpecMessage.LISTENER_SLEEP, handle_sleep)
     bus.on("recognizer_loop:wake_up", handle_wake_up)
     bus.on("mycroft.mic.mute", handle_mic_mute)
     bus.on("mycroft.mic.unmute", handle_mic_unmute)
     bus.on("mycroft.mic.get_status", handle_mic_get_status)
-    bus.on("mycroft.mic.listen", handle_mic_listen)
-    bus.on("recognizer_loop:audio_output_start", handle_audio_start)
-    bus.on("recognizer_loop:audio_output_end", handle_audio_end)
+    bus.on(SpecMessage.MIC_LISTEN, handle_mic_listen)
+    bus.on(SpecMessage.AUDIO_OUTPUT_STARTED, handle_audio_start)
+    bus.on(SpecMessage.AUDIO_OUTPUT_ENDED, handle_audio_end)
     bus.on("mycroft.stop", handle_stop)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ dependencies = [
     "ovos-plugin-manager>=2.1.1,<3.0.0",
     "ovos-utils>=0.8.4,<1.0.0",
     "ovos-config>=1.2.2,<3.0.0",
-    "ovos_bus_client>=1.3.4,<3.0.0",
+    "ovos_bus_client>=2.2.0a1,<3.0.0",
+    "ovos-spec-tools>=0.9.0a1,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.10"
 
 dependencies = [
     "PyAudio~=0.2",
-    "ovos-plugin-manager>=2.1.1,<3.0.0",
+    "ovos-plugin-manager>=2.5.0a1,<3.0.0",
     "ovos-utils>=0.8.4,<1.0.0",
     "ovos-config>=1.2.2,<3.0.0",
     "ovos_bus_client>=2.2.0a1,<3.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ PyAudio~=0.2
 ovos-plugin-manager>=2.1.1,<3.0.0
 ovos-utils>=0.8.4,<1.0.0
 ovos-config>=1.2.2,<3.0.0
-ovos_bus_client>=1.3.4,<3.0.0
+ovos_bus_client>=2.2.0a1,<3.0.0
+ovos-spec-tools>=0.9.0a1,<1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyAudio~=0.2
-ovos-plugin-manager>=2.1.1,<3.0.0
+ovos-plugin-manager>=2.5.0a1,<3.0.0
 ovos-utils>=0.8.4,<1.0.0
 ovos-config>=1.2.2,<3.0.0
 ovos_bus_client>=2.2.0a1,<3.0.0

--- a/test/unittests/test_service_handlers.py
+++ b/test/unittests/test_service_handlers.py
@@ -62,7 +62,7 @@ class TestHandleRecordBegin(unittest.TestCase):
         svc.bus = bus
         svc.handle_record_begin()
         msg = bus.emit.call_args[0][0]
-        self.assertEqual(msg.msg_type, "recognizer_loop:record_begin")
+        self.assertEqual(msg.msg_type, "ovos.listener.record.started")
 
     def test_context_has_client_name(self):
         import mycroft_classic_listener.service as svc
@@ -82,7 +82,7 @@ class TestHandleRecordEnd(unittest.TestCase):
         svc.bus = bus
         svc.handle_record_end()
         msg = bus.emit.call_args[0][0]
-        self.assertEqual(msg.msg_type, "recognizer_loop:record_end")
+        self.assertEqual(msg.msg_type, "ovos.listener.record.ended")
 
 
 # ---------------------------------------------------------------------------
@@ -109,7 +109,7 @@ class TestHandleAwoken(unittest.TestCase):
         svc.bus = bus
         svc.handle_awoken()
         msg = bus.emit.call_args[0][0]
-        self.assertEqual(msg.msg_type, "mycroft.awoken")
+        self.assertEqual(msg.msg_type, "ovos.listener.awoken")
 
 
 # ---------------------------------------------------------------------------
@@ -153,7 +153,7 @@ class TestHandleUtterance(unittest.TestCase):
         event = {"utterances": ["hello world"], "lang": "en-us"}
         svc.handle_utterance(event)
         msg = bus.emit.call_args[0][0]
-        self.assertEqual(msg.msg_type, "recognizer_loop:utterance")
+        self.assertEqual(msg.msg_type, "ovos.utterance.handle")
 
     def test_context_destination_is_skills(self):
         import mycroft_classic_listener.service as svc
@@ -431,14 +431,14 @@ class TestConnectBusEvents(unittest.TestCase):
         registered = {c[0][0] for c in bus.on.call_args_list}
         expected = {
             "open",
-            "recognizer_loop:sleep",
+            "ovos.listener.sleep",
             "recognizer_loop:wake_up",
             "mycroft.mic.mute",
             "mycroft.mic.unmute",
             "mycroft.mic.get_status",
-            "mycroft.mic.listen",
-            "recognizer_loop:audio_output_start",
-            "recognizer_loop:audio_output_end",
+            "ovos.mic.listen",
+            "ovos.audio.output.started",
+            "ovos.audio.output.ended",
             "mycroft.stop",
         }
         self.assertEqual(registered, expected)


### PR DESCRIPTION
## What

Migrate the listener's bus topics to the canonical OVOS spec `ovos.*`
namespace by replacing legacy `mycroft.*`/`recognizer_loop:*` topic
strings with `SpecMessage` members from `ovos-spec-tools`.

`SpecMessage` is a `str`-`Enum`, so members are used directly as bus
topics in `bus.emit(Message(...))` / `bus.on(...)`.

### Topic mapping (real bus usages only)

| legacy | spec member | value |
| --- | --- | --- |
| `recognizer_loop:utterance` | `SpecMessage.UTTERANCE` | `ovos.utterance.handle` |
| `recognizer_loop:record_begin` | `SpecMessage.LISTENER_RECORD_STARTED` | `ovos.listener.record.started` |
| `recognizer_loop:record_end` | `SpecMessage.LISTENER_RECORD_ENDED` | `ovos.listener.record.ended` |
| `recognizer_loop:sleep` | `SpecMessage.LISTENER_SLEEP` | `ovos.listener.sleep` |
| `mycroft.awoken` | `SpecMessage.LISTENER_AWOKEN` | `ovos.listener.awoken` |
| `recognizer_loop:audio_output_start` | `SpecMessage.AUDIO_OUTPUT_STARTED` | `ovos.audio.output.started` |
| `recognizer_loop:audio_output_end` | `SpecMessage.AUDIO_OUTPUT_ENDED` | `ovos.audio.output.ended` |
| `mycroft.mic.listen` | `SpecMessage.MIC_LISTEN` | `ovos.mic.listen` |

### Scope notes

- Only **real bus topics** were migrated (`bus.emit`/`bus.on` in `service.py`).
- Internal `RecognizerLoop` (pyee `EventEmitter`) signals in `mic.py`,
  `listener.py`, and the `loop.on(...)` registrations in `service.py`
  are **not** bus topics and were intentionally left unchanged.
- Unrelated topics (`mycroft.audio.*`, `mycroft.mic.mute/unmute/get_status`,
  `recognizer_loop:wake_up`, `mycroft.stop`, `speak`, etc.) are untouched.
- Unit tests asserting the old topics were updated.

### Compatibility

The `MessageBusClient` namespace-migration feature (both flags default ON)
transparently also-emits the legacy counterpart on emit and dedupes
dual-listeners, so un-migrated peers keep working.

## Deps

- add `ovos-spec-tools>=0.9.0a1,<1.0.0`
- bump `ovos_bus_client>=2.2.0a1,<3.0.0` (namespace-aware client)

Updated both `pyproject.toml` and `requirements.txt` (setup.py reads the latter).

## Tests

`53 passed` locally (spec-tools provided via `PYTHONPATH` to the unreleased
`SpecMessage` build).

## Stacked / CI

CI will be RED until these publish:
- ovos-spec-tools#26 (adds `SpecMessage`)
- ovos-bus-client#230 (namespace-aware client / floor `2.2.0a1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
