### PR TITLE
fix: lift ovos-spec-tools upper bound (spec-tools 1.x)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "ovos-utils>=0.8.4,<1.0.0",
     "ovos-config>=1.2.2,<3.0.0",
     "ovos_bus_client>=2.2.0a1,<3.0.0",
-    "ovos-spec-tools>=0.9.0a1,<1.0.0",
+    "ovos-spec-tools>=0.9.0a1",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ ovos-plugin-manager>=2.5.0a1,<3.0.0
 ovos-utils>=0.8.4,<1.0.0
 ovos-config>=1.2.2,<3.0.0
 ovos_bus_client>=2.2.0a1,<3.0.0
-ovos-spec-tools>=0.9.0a1,<1.0.0
+ovos-spec-tools>=0.9.0a1


### PR DESCRIPTION
spec-tools crossed to 1.x (1.1.0a1 published) — PR #63 (`fix!`) dropped the handler-trio entries from the namespace migration bridge. Consumers capping `ovos-spec-tools<1.0.0` can no longer resolve against the current stack (e.g. ovos-bus-client 2.6.0a1 requires `ovos-spec-tools>=1.1.0a1`).

This drops the upper bound entirely (keeps the floor) so the stack resolves. Verified: with the uncapped floor, uv resolves `ovos-spec-tools==1.1.0a1` alongside `ovos-bus-client==2.6.0a1` with no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Lifted in both `pyproject.toml` and `requirements.txt` (the repo's `setup.py` still reads `requirements.txt` via `install_requires`, so they must stay in sync).